### PR TITLE
Fix for fastlane update and npm install

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -69,6 +69,7 @@ node('mac-vm-host') {
                         xcodebuild -version
                         pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
                         sudo xcodebuild -license accept
+                        gem install fastlane --no-document
                         fastlane clearCache
                         fastlane prepare
                         pip install virtualenv

--- a/Jenkinsfile.publish
+++ b/Jenkinsfile.publish
@@ -67,6 +67,7 @@ node('mac-vm-host') {
                         xcodebuild -version
                         pkgutil --pkg-info=com.apple.pkg.CLTools_Executables
                         sudo xcodebuild -license accept
+                        gem install fastlane --no-document
                         fastlane clearCache
                         fastlane prepare
                         pip install virtualenv

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,7 +7,7 @@
 #
 
 # Uncomment the line if you want fastlane to automatically update itself
-update_fastlane
+# update_fastlane
 
 default_platform(:ios)
 
@@ -49,7 +49,7 @@ platform :ios do
   lane :clearCache do
 
     # Remove the Cache
-    sh("cd .. && rm -rf Cartfile.resolved Carthage node_modules Podfile.lock Pods && rm -rf ~/Library/Caches/org.carthage.CarthageKit")
+    sh("cd .. && npm cache clean --force && rm -rf Cartfile.resolved Carthage node_modules Podfile.lock Pods && rm -rf ~/Library/Caches/org.carthage.CarthageKit")
 
   end
 


### PR DESCRIPTION
- Removed 'fastlane update' from Fastfile and now Fastlane updates from Jenkinsfile instead.
- Added 'npm cache clean --force' in clearCache Lane. This is the fix for 'npm install' failing sometimes.