### PR TITLE
[IP-538] Making promo codes (somewhat) case-insensitive

### DIFF
--- a/Cliqz/Upgrade&Payment/Cotroller/PromoCodesManager.swift
+++ b/Cliqz/Upgrade&Payment/Cotroller/PromoCodesManager.swift
@@ -59,8 +59,16 @@ class PromoCodesManager {
     
     private var staticPromoList: [JSON] {
         let promo1 = ["code": "OHBABY", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
-        let promo2 = ["code": "OBABY", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
-        let promo3 = ["code": "LUMEN2019", "ID": "com.cliqz.ios.lumen.promo.half.basic_vpn", "type": "half"]
-        return [JSON(promo1), JSON(promo2), JSON(promo3)]
+        let promo2 = ["code": "ohbaby", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
+        let promo3 = ["code": "Ohbaby", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
+        let promo4 = ["code": "OhBaby", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
+        let promo5 = ["code": "OBABY", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
+        let promo6 = ["code": "Obaby", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
+        let promo7 = ["code": "obaby", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
+        let promo8 = ["code": "OBaby", "ID": "com.cliqz.ios.lumen.promo.free.basic_vpn", "type": "freeMonth"] as [String: Any]
+        let promo9 = ["code": "LUMEN2019", "ID": "com.cliqz.ios.lumen.promo.half.basic_vpn", "type": "half"]
+        let promo10 = ["code": "lumen2019", "ID": "com.cliqz.ios.lumen.promo.half.basic_vpn", "type": "half"]
+        let promo11 = ["code": "Lumen2019", "ID": "com.cliqz.ios.lumen.promo.half.basic_vpn", "type": "half"]
+        return [JSON(promo1), JSON(promo2), JSON(promo3), JSON(promo4), JSON(promo5), JSON(promo6), JSON(promo7), JSON(promo8), JSON(promo9), JSON(promo10), JSON(promo11)]
     }
 }


### PR DESCRIPTION
The IP-538 specified that codes should not be case-sensitive, that is to ignore capitalization (e.g., LUMEN2019, lumen2019, Lumen2019, etc. are all valid).

This is a quick fix to capture the most likely spellings of the supported codes.

@pavel-cliqz 