### PR TITLE
Fix a Crash in Query Suggestions

### DIFF
--- a/Client/Frontend/Browser/SearchSuggestClient.swift
+++ b/Client/Frontend/Browser/SearchSuggestClient.swift
@@ -58,7 +58,7 @@ class SearchSuggestClient {
 
                 // Check if we got any data at all
                 guard data.count > 0 else {
-                    callback(nil, nil)
+                    callback([], nil)
                     return
                 }
 


### PR DESCRIPTION
This fixes a crash that happened when button mashing in the address bar. 

## Notes for testing this patch
Button mashing in the address bar should no longer crash the app.
