### PR TITLE
[IP-535] Fix a possible error in VPN

### DIFF
--- a/Cliqz/HomePanel/VPN/VPNEndPointManager.swift
+++ b/Cliqz/HomePanel/VPN/VPNEndPointManager.swift
@@ -111,7 +111,14 @@ class VPNEndPointManager {
                 return
             }
 
-            guard let self = self, credentials.count > 0 else { return }
+            guard let self = self, credentials.count > 0 else {
+                NotificationCenter.default.post(
+                    name: VPNEndPointManager.countriesUpdateErrorNotification,
+                    object: nil,
+                    userInfo: nil
+                )
+                return
+            }
             self.countries.removeAll()
             
             for cred in credentials {


### PR DESCRIPTION
Possible fix for a problem where no failure notification would get sent on empty VPN credentials list

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
## Pull Request Checklist

- [x] My PR has a standard commit message that looks like `[IP-123] This fixes something something`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

## Notes for testing this patch

<!-- If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified. -->


[IP-123]: https://cliqztix.atlassian.net/browse/IP-123