### PR TITLE
[IB-1926] [Bug] Updated MappaMundi breaks build

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -16,4 +16,5 @@ github "farhanpatel/JSONSchema.swift"       "master"
 # Cliqz: Disable FireFox Telemetry & EarlyGray
 # github "st3fan/EarlGrey"                    "master"
 # github "mozilla-mobile/telemetry-ios"       "v1.1.0"
-github "mozilla-mobile/MappaMundi"          "master"
+# Cliqz: Pinning MappaMundi to a specific commit because newer versions require A-Star, which requires Swift 5
+github "mozilla-mobile/MappaMundi"          "02b6f0b404d0a7178c47c073550936016f42981e"


### PR DESCRIPTION
The Cartfile we inherited from Firefox contains this line:

```
github "mozilla-mobile/MappaMundi"          "master"
```

recently, MappaMundi was [updated to use the A-Star project](https://github.com/mozilla-mobile/MappaMundi/pull/17) for pathfinding. This project, however, needs Swift 5. Hence, the build is broken.

To fix, pin the MappaMundi version to a commit before they introduce the A-Star algorithm.

<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
## Pull Request Checklist

- [x] My PR has a standard commit message that looks like `[IP-123] This fixes something something`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

## Notes for testing this patch

<!-- If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified. -->


[IP-123]: https://cliqztix.atlassian.net/browse/IP-123