### PR TITLE
[IB-1923] Circumvent erroneous localization by not localizing the string “Pause”

### DIFF
--- a/Cliqz/Privacy/UI/ControlCenter/OverviewViewController.swift
+++ b/Cliqz/Privacy/UI/ControlCenter/OverviewViewController.swift
@@ -836,7 +836,8 @@ class OverviewViewController: UIViewController {
 		self.restrictSiteButton.setTitle(restrictTitle, for: .normal)
 		self.restrictSiteButton.addTarget(self, action: #selector(restrictSitePressed), for: .touchUpInside)
 
-		let pauseGhostery = NSLocalizedString("Pause Ghostery", tableName: "Cliqz", comment: "[ControlCenter -> Overview] Pause Ghostery button title")
+        // Forcing the string instead of using LocalizedString because the L10n system is playing charades 
+		let pauseGhostery = "Pause"
 		self.pauseGhosteryButton.setTitle(pauseGhostery, for: .normal)
         self.pauseGhosteryButton.addTarget(self, action: #selector(pauseGhosteryPressed), for: .touchUpInside)
         self.pauseGhosteryButton.titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: UIFont.Weight.medium)


### PR DESCRIPTION
<!-- 
*Thank you for submitting a pull request, your contributions are greatly appreciated!*

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
## Pull Request Checklist

- [ ] My PR has a standard commit message that looks like `[IP-123] This fixes something something`
- [ ] I have updated the *Unit Tests* to cover new or changed functionality
- [ ] I have made sure that localizable strings use `NSLocalizableString()`

## Screenshots

<!-- If your patch includes user interface changes that you would like to suggest or that you would like UX to look at, please include them here. -->

## Notes for testing this patch

<!-- If useful, please leave notes for QA, explaining what this patch changes and how it can be best tested and verified. -->


[IP-123]: https://cliqztix.atlassian.net/browse/IP-123