### PR TITLE
[IB-1894] Migrate Bookmarks over from old Cliqz #392

### DIFF
--- a/Client.xcodeproj/project.pbxproj
+++ b/Client.xcodeproj/project.pbxproj
@@ -562,6 +562,7 @@
 		A83E5B1E1C1DAAAA0026D912 /* UIPasteboardExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83E5AB61C1D993D0026D912 /* UIPasteboardExtensions.swift */; };
 		A9072B801D07B34100459960 /* NoImageModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */; };
 		A93067E81D0FE18E00C49C6E /* NightModeHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */; };
+		AC2CC50722DF064600C5C85C /* BrowserDBExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2CC4FD22DF05F200C5C85C /* BrowserDBExtensions.swift */; };
 		AF03AA1A20BC117600A9D097 /* LoadTrackerListOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03AA1920BC117600A9D097 /* LoadTrackerListOperation.swift */; };
 		AF03AA2A20BC129A00A9D097 /* ApplyDefaultsOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF03AA2920BC129A00A9D097 /* ApplyDefaultsOperation.swift */; };
 		AF235043213D482900A0CB8A /* ChangeTrackersOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF235042213D482800A0CB8A /* ChangeTrackersOperation.swift */; };
@@ -1672,6 +1673,7 @@
 		28FDFF0B1C1F725800840F86 /* SeparatorTableCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SeparatorTableCell.swift; sourceTree = "<group>"; };
 		2979623822DF695E00604955 /* Onboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Onboarding.swift; sourceTree = "<group>"; };
 		2979624222DF697900604955 /* OnboardingBridge.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnboardingBridge.m; sourceTree = "<group>"; };
+		29D93543AEB0D88056BBFEBE /* Pods-Client.cliqzdebug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Client.cliqzdebug.xcconfig"; path = "Pods/Target Support Files/Pods-Client/Pods-Client.cliqzdebug.xcconfig"; sourceTree = "<group>"; };
 		2C28F96B201B2D4C00ABA8A5 /* MailAppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailAppSettingsTests.swift; sourceTree = "<group>"; };
 		2C2A5EF31E68469500F02659 /* PrivateBrowsingTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrivateBrowsingTest.swift; sourceTree = "<group>"; };
 		2C2A91281FA2410D002E36BD /* HistoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryTests.swift; sourceTree = "<group>"; };
@@ -1969,6 +1971,7 @@
 		74B195431CF503FC007F36EF /* RecentlyClosedTabs.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentlyClosedTabs.swift; sourceTree = "<group>"; };
 		74C027441B2A348C001B1E88 /* SessionData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionData.swift; sourceTree = "<group>"; };
 		74E36D771B71323500D69DA1 /* SettingsContentViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsContentViewController.swift; sourceTree = "<group>"; };
+		7AB31CEE0D75A459EC44D394 /* Pods-Storage.cliqzdebug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.cliqzdebug.xcconfig"; path = "Pods/Target Support Files/Pods-Storage/Pods-Storage.cliqzdebug.xcconfig"; sourceTree = "<group>"; };
 		7B10AA9E1E3A15020002DD08 /* DataExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataExtensions.swift; sourceTree = "<group>"; };
 		7B10AABA1E3A1F650002DD08 /* URLRequestExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRequestExtensions.swift; sourceTree = "<group>"; };
 		7B2142FD1E5E055000CDD3FC /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -2015,6 +2018,7 @@
 		A9072B7F1D07B34100459960 /* NoImageModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoImageModeHelper.swift; sourceTree = "<group>"; };
 		A93067E71D0FE18E00C49C6E /* NightModeHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NightModeHelper.swift; sourceTree = "<group>"; };
 		ABDC69EC66F406D5306BF0A7 /* Pods-Storage.fennec.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Storage.fennec.xcconfig"; path = "Pods/Target Support Files/Pods-Storage/Pods-Storage.fennec.xcconfig"; sourceTree = "<group>"; };
+		AC2CC4FD22DF05F200C5C85C /* BrowserDBExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDBExtensions.swift; sourceTree = "<group>"; };
 		AF03AA1920BC117600A9D097 /* LoadTrackerListOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadTrackerListOperation.swift; sourceTree = "<group>"; };
 		AF03AA2920BC129A00A9D097 /* ApplyDefaultsOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplyDefaultsOperation.swift; sourceTree = "<group>"; };
 		AF235042213D482800A0CB8A /* ChangeTrackersOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeTrackersOperation.swift; sourceTree = "<group>"; };
@@ -3466,6 +3470,7 @@
 				1EA949F720EFB956008D32A6 /* TopTabsViewControllerExtension.swift */,
 				1EA51578212D54E5008DEF0D /* UIViewExtension.swift */,
 				1E351C5C21D28AF700275941 /* ThemeExtentions.swift */,
+				AC2CC4FD22DF05F200C5C85C /* BrowserDBExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -3868,6 +3873,8 @@
 				E3D01FBAD9B329F45EAFE4BB /* Pods-Storage.lumendebug.xcconfig */,
 				6F4255CFD868632566C61A36 /* Pods-Client.cliqz.xcconfig */,
 				F5FBD48DBCB2CA781FAEC068 /* Pods-Storage.cliqz.xcconfig */,
+				29D93543AEB0D88056BBFEBE /* Pods-Client.cliqzdebug.xcconfig */,
+				7AB31CEE0D75A459EC44D394 /* Pods-Storage.cliqzdebug.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -6091,7 +6098,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Client/Pods-Client-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Client/Pods-Client-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSSNS/AWSSNS.framework",
 				"${BUILT_PRODUCTS_DIR}/CRToast/CRToast.framework",
@@ -6144,7 +6151,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Client/Pods-Client-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Client/Pods-Client-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E6639F191BF11E3A002D0853 /* Conditionally Add Settings Bundle */ = {
@@ -6393,6 +6400,7 @@
 				28E08C991AF44EF9009BA2FA /* SQLiteHistory.swift in Sources */,
 				285D3B901B4386520035FD22 /* SQLiteQueue.swift in Sources */,
 				28532D321C483E3D000072D9 /* CompletionOps.swift in Sources */,
+				AC2CC50722DF064600C5C85C /* BrowserDBExtensions.swift in Sources */,
 				2FCAE25D1ABB531100877008 /* Bookmarks.swift in Sources */,
 				394CF6CF1BAA493C00906917 /* DefaultSuggestedSites.swift in Sources */,
 				2FCAE2781ABB531100877008 /* Visit.swift in Sources */,
@@ -12015,6 +12023,855 @@
 			};
 			name = FirefoxBeta;
 		};
+		AC2CC4DB22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 4F895F5F22B124BC002E6F0C /* Cliqz.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = NO;
+				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_ACTIVITY_MODE = "";
+				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(SRCROOT)/ThirdParty/sqlcipher",
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+					"$(SDKROOT)/usr/include/libxml2",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)";
+				MOZ_INTERNAL_URL_SCHEME = cliqz;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lxml2",
+				);
+				OTHER_SWIFT_FLAGS = "-DMOZ_CHANNEL_RELEASE";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";
+				SWIFT_INCLUDE_PATHS = "$(PROJECT_DIR)/Storage/modules";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4DC22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 29D93543AEB0D88056BBFEBE /* Pods-Client.cliqzdebug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = CliqzAppIcon;
+				CODE_SIGN_ENTITLEMENTS = "$(CLIENT_ENTITLEMENT)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 2UYYSSHVUH;
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/ThirdParty/BuddyBuild",
+					"$(PROJECT_DIR)/ThirdParty/Leanplum",
+					"$(PROJECT_DIR)/Cliqz/Third-Party/KKDomain/Carthage/Build/iOS",
+					"$(PROJECT_DIR)/Cliqz/Third-Party/KKDomain/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Cliqz/Third-Party/KKDomain/Carthage/Build/tvOS",
+					"$(PROJECT_DIR)/Cliqz/Third-Party/KKDomain/Carthage/Build/watchOS",
+					"$(PROJECT_DIR)/node_modules/react-native-webrtc/ios",
+				);
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"DEBUG=1",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+					"$(SDKROOT)/usr/include/libxml2",
+					"$(BUILD_DIR)/Debug$(EFFECTIVE_PLATFORM_NAME)/include/**",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+				);
+				INCLUDE_SETTINGS_BUNDLE = YES;
+				INFOPLIST_FILE = Client/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = cliqz;
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lxml2",
+					"$(inherited)",
+				);
+				OTHER_SWIFT_FLAGS = "-DMOZ_CHANNEL_RELEASE -DMOZ_TARGET_CLIENT -DCLIQZ";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID)";
+				PRODUCT_MODULE_NAME = Client;
+				PRODUCT_NAME = Client;
+				PROVISIONING_PROFILE = "a6da668a-0207-4e12-872b-a679ce75d464";
+				PROVISIONING_PROFILE_SPECIFIER = "CLIQZ App Store";
+				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/Client-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4DD22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 2UYYSSHVUH;
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = Extensions/NotificationService/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = cliqz;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_SWIFT_FLAGS = "-DMOZ_CHANNEL_RELEASE -DMOZ_TARGET_NOTIFICATIONSERVICE";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID).NotificationService";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "22698f18-e032-49c5-8c20-11c32703ab4f";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore *";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4DE22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = "$(CLIENT_ENTITLEMENT)";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = 2UYYSSHVUH;
+				ENABLE_BITCODE = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				INFOPLIST_FILE = Extensions/ShareTo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = cliqz;
+				OTHER_SWIFT_FLAGS = "-DMOZ_CHANNEL_RELEASE -DMOZ_TARGET_SHARETO -DCLIQZ";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_SHARETO_ID)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "CliqzShareTo Distribution";
+				SKIP_INSTALL = YES;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4DF22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_BITCODE = NO;
+				INFOPLIST_FILE = Extensions/Today/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../../Frameworks";
+				MOZ_INTERNAL_URL_SCHEME = cliqz;
+				OTHER_SWIFT_FLAGS = "-DMOZ_CHANNEL_RELEASE -DMOZ_TARGET_TODAY";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(MOZ_BUNDLE_ID).Today";
+				PRODUCT_NAME = Today;
+				PROVISIONING_PROFILE = "22698f18-e032-49c5-8c20-11c32703ab4f";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 4.0;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E022DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				INFOPLIST_FILE = "Shared/Supporting Files/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Shared/Shared-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E122DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7AB31CEE0D75A459EC44D394 /* Pods-Storage.cliqzdebug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = "SQLITE_HAS_CODEC=1";
+				INFOPLIST_FILE = Storage/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = "-DSQLITE_HAS_CODEC";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Storage/Storage-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E222DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				HEADER_SEARCH_PATHS = (
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)",
+					"$(SDKROOT)/usr/include/libxml2",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)/include/**",
+				);
+				INFOPLIST_FILE = Account/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E322DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				INFOPLIST_FILE = Sync/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Sync/Sync-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E422DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = SyncTelemetry/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.SyncTelemetry;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E522DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
+				INFOPLIST_FILE = ClientTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.ios.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = ClientTests;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E622DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "org.allizom.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = UITests;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E722DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				INFOPLIST_FILE = StorageTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Storage/Storage-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E822DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				INFOPLIST_FILE = AccountTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Account/Account-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4E922DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+					"$(BUILD_DIR)/Release$(EFFECTIVE_PLATFORM_NAME)",
+				);
+				INFOPLIST_FILE = SyncTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/SyncTests/SyncTests-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4EA22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = SharedTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = "org.mozilla.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "$SRCROOT/Shared/Shared-Bridging-Header.h";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4EB22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = L10nSnapshotTests;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TEST_TARGET_NAME = Client;
+				USES_XCTRUNNER = YES;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4EC22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = MarketingUITests;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4ED22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = XCUITests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.XCUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TEST_TARGET_NAME = Client;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4EE22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = StoragePerfTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mozilla.StoragePerfTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4EF22DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 43AQ936H96;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = SyncTelemetryTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = org.mozilla.ios.SyncTelemetryTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4F022DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 2UYYSSHVUH;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = AppiumTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = cliqz.ios.newCliqz.AppiumTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Client;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = CliqzDebug;
+		};
+		AC2CC4F122DE026C00C5C85C /* CliqzDebug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 2UYYSSHVUH;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				INFOPLIST_FILE = UnitTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.evidon.Ghostery.UnitTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Client.app/Client";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = CliqzDebug;
+		};
 		C543E474225CC88A00CFF083 /* LumenDebug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1E79A98D21A6F89C00EAC6E6 /* Lumen.xcconfig */;
@@ -15063,6 +15920,7 @@
 				1E78A3A0214BBAF5005E2539 /* Fennec_Enterprise */,
 				1E78A3A1214BBAF5005E2539 /* Firefox */,
 				4F895F7F22B12631002E6F0C /* Cliqz */,
+				AC2CC4F122DE026C00C5C85C /* CliqzDebug */,
 				1E78A3A2214BBAF5005E2539 /* Ghostery */,
 				1E0B0B76217485810088C520 /* Paid */,
 				1E79A98421A6F87300EAC6E6 /* Lumen */,
@@ -15079,6 +15937,7 @@
 				E6DCC20E1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA81AEE7A6000869B6C /* Firefox */,
 				4F895F7122B12631002E6F0C /* Cliqz */,
+				AC2CC4E322DE026C00C5C85C /* CliqzDebug */,
 				1EE3850C21416BB600B7F722 /* Ghostery */,
 				1E0B0B68217485810088C520 /* Paid */,
 				1E79A97621A6F87300EAC6E6 /* Lumen */,
@@ -15095,6 +15954,7 @@
 				E6DCC2151DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA91AEE7A6000869B6C /* Firefox */,
 				4F895F7722B12631002E6F0C /* Cliqz */,
+				AC2CC4E922DE026C00C5C85C /* CliqzDebug */,
 				1EE3851221416BB600B7F722 /* Ghostery */,
 				1E0B0B6E217485810088C520 /* Paid */,
 				1E79A97C21A6F87300EAC6E6 /* Lumen */,
@@ -15111,6 +15971,7 @@
 				E6DCC20B1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA31AEE7A6000869B6C /* Firefox */,
 				4F895F6E22B12631002E6F0C /* Cliqz */,
+				AC2CC4E022DE026C00C5C85C /* CliqzDebug */,
 				1EE3850921416BB600B7F722 /* Ghostery */,
 				1E0B0B65217485810088C520 /* Paid */,
 				1E79A97321A6F87300EAC6E6 /* Lumen */,
@@ -15127,6 +15988,7 @@
 				E6DCC20D1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA61AEE7A6000869B6C /* Firefox */,
 				4F895F7022B12631002E6F0C /* Cliqz */,
+				AC2CC4E222DE026C00C5C85C /* CliqzDebug */,
 				1EE3850B21416BB600B7F722 /* Ghostery */,
 				1E0B0B67217485810088C520 /* Paid */,
 				1E79A97521A6F87300EAC6E6 /* Lumen */,
@@ -15143,6 +16005,7 @@
 				E6DCC2141DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA71AEE7A6000869B6C /* Firefox */,
 				4F895F7622B12631002E6F0C /* Cliqz */,
+				AC2CC4E822DE026C00C5C85C /* CliqzDebug */,
 				1EE3851121416BB600B7F722 /* Ghostery */,
 				1E0B0B6D217485810088C520 /* Paid */,
 				1E79A97B21A6F87300EAC6E6 /* Lumen */,
@@ -15159,6 +16022,7 @@
 				E6DCC20C1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA41AEE7A6000869B6C /* Firefox */,
 				4F895F6F22B12631002E6F0C /* Cliqz */,
+				AC2CC4E122DE026C00C5C85C /* CliqzDebug */,
 				1EE3850A21416BB600B7F722 /* Ghostery */,
 				1E0B0B66217485810088C520 /* Paid */,
 				1E79A97421A6F87300EAC6E6 /* Lumen */,
@@ -15175,6 +16039,7 @@
 				E6DCC2131DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA51AEE7A6000869B6C /* Firefox */,
 				4F895F7522B12631002E6F0C /* Cliqz */,
+				AC2CC4E722DE026C00C5C85C /* CliqzDebug */,
 				1EE3851021416BB600B7F722 /* Ghostery */,
 				1E0B0B6C217485810088C520 /* Paid */,
 				1E79A97A21A6F87300EAC6E6 /* Lumen */,
@@ -15191,6 +16056,7 @@
 				E6DCC2091DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				39409A411C90E68300DAE683 /* Firefox */,
 				4F895F6D22B12631002E6F0C /* Cliqz */,
+				AC2CC4DF22DE026C00C5C85C /* CliqzDebug */,
 				1EE3850821416BB600B7F722 /* Ghostery */,
 				1E0B0B64217485810088C520 /* Paid */,
 				1E79A97221A6F87300EAC6E6 /* Lumen */,
@@ -15206,6 +16072,7 @@
 				C543E476225CC88A00CFF083 /* LumenDebug */,
 				397848E51ED86605004C0C0B /* Firefox */,
 				4F895F6B22B12631002E6F0C /* Cliqz */,
+				AC2CC4DD22DE026C00C5C85C /* CliqzDebug */,
 				1EE3850621416BB600B7F722 /* Ghostery */,
 				1E0B0B62217485810088C520 /* Paid */,
 				1E79A97021A6F87300EAC6E6 /* Lumen */,
@@ -15223,6 +16090,7 @@
 				E6DCC21B1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				3B43E3D81D95C48E00BBA9DB /* Firefox */,
 				4F895F7C22B12631002E6F0C /* Cliqz */,
+				AC2CC4EE22DE026C00C5C85C /* CliqzDebug */,
 				1EE3851721416BB600B7F722 /* Ghostery */,
 				1E0B0B73217485810088C520 /* Paid */,
 				1E79A98121A6F87300EAC6E6 /* Lumen */,
@@ -15239,6 +16107,7 @@
 				E6DCC21A1DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				3BFE4B0F1D342FB900DDF53F /* Firefox */,
 				4F895F7B22B12631002E6F0C /* Cliqz */,
+				AC2CC4ED22DE026C00C5C85C /* CliqzDebug */,
 				1EE3851621416BB600B7F722 /* Ghostery */,
 				1E0B0B72217485810088C520 /* Paid */,
 				1E79A98021A6F87300EAC6E6 /* Lumen */,
@@ -15255,6 +16124,7 @@
 				82F4343B207E44C100FA40AF /* Fennec_Enterprise */,
 				82F4343C207E44C100FA40AF /* Firefox */,
 				4F895F7E22B12631002E6F0C /* Cliqz */,
+				AC2CC4F022DE026C00C5C85C /* CliqzDebug */,
 				1EE3851921416BB600B7F722 /* Ghostery */,
 				1E0B0B75217485810088C520 /* Paid */,
 				1E79A98321A6F87300EAC6E6 /* Lumen */,
@@ -15272,6 +16142,7 @@
 				D39FA1691A83E0EC00EE869C /* Release */,
 				E448FCA21AEE7A6000869B6C /* Firefox */,
 				4F895F7422B12631002E6F0C /* Cliqz */,
+				AC2CC4E622DE026C00C5C85C /* CliqzDebug */,
 				1EE3850F21416BB600B7F722 /* Ghostery */,
 				1E0B0B6B217485810088C520 /* Paid */,
 				1E79A97921A6F87300EAC6E6 /* Lumen */,
@@ -15288,6 +16159,7 @@
 				E6DCC2181DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E601384D1C89EAE600DF9756 /* Firefox */,
 				4F895F7922B12631002E6F0C /* Cliqz */,
+				AC2CC4EB22DE026C00C5C85C /* CliqzDebug */,
 				1EE3851421416BB600B7F722 /* Ghostery */,
 				1E0B0B70217485810088C520 /* Paid */,
 				1E79A97E21A6F87300EAC6E6 /* Lumen */,
@@ -15304,6 +16176,7 @@
 				E6DCC2191DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E60138521C89EAE600DF9756 /* Firefox */,
 				4F895F7A22B12631002E6F0C /* Cliqz */,
+				AC2CC4EC22DE026C00C5C85C /* CliqzDebug */,
 				1EE3851521416BB600B7F722 /* Ghostery */,
 				1E0B0B71217485810088C520 /* Paid */,
 				1E79A97F21A6F87300EAC6E6 /* Lumen */,
@@ -15320,6 +16193,7 @@
 				E69DB08E1E97DEAA008A67E6 /* Fennec_Enterprise */,
 				E69DB08F1E97DEAA008A67E6 /* Firefox */,
 				4F895F7222B12631002E6F0C /* Cliqz */,
+				AC2CC4E422DE026C00C5C85C /* CliqzDebug */,
 				1EE3850D21416BB600B7F722 /* Ghostery */,
 				1E0B0B69217485810088C520 /* Paid */,
 				1E79A97721A6F87300EAC6E6 /* Lumen */,
@@ -15336,6 +16210,7 @@
 				E69DB0941E97DEAA008A67E6 /* Fennec_Enterprise */,
 				E69DB0951E97DEAA008A67E6 /* Firefox */,
 				4F895F7D22B12631002E6F0C /* Cliqz */,
+				AC2CC4EF22DE026C00C5C85C /* CliqzDebug */,
 				1EE3851821416BB600B7F722 /* Ghostery */,
 				1E0B0B74217485810088C520 /* Paid */,
 				1E79A98221A6F87300EAC6E6 /* Lumen */,
@@ -15352,6 +16227,7 @@
 				E6DCC2171DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E6F965171B2F1CF20034B023 /* Firefox */,
 				4F895F7822B12631002E6F0C /* Cliqz */,
+				AC2CC4EA22DE026C00C5C85C /* CliqzDebug */,
 				1EE3851321416BB600B7F722 /* Ghostery */,
 				1E0B0B6F217485810088C520 /* Paid */,
 				1E79A97D21A6F87300EAC6E6 /* Lumen */,
@@ -15368,6 +16244,7 @@
 				E6DCC2051DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FC9D1AEE7A6000869B6C /* Firefox */,
 				4F895F6922B12631002E6F0C /* Cliqz */,
+				AC2CC4DB22DE026C00C5C85C /* CliqzDebug */,
 				1EE3850421416BB600B7F722 /* Ghostery */,
 				1E0B0B60217485810088C520 /* Paid */,
 				1E79A96E21A6F87300EAC6E6 /* Lumen */,
@@ -15384,6 +16261,7 @@
 				E6DCC2061DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FC9E1AEE7A6000869B6C /* Firefox */,
 				4F895F6A22B12631002E6F0C /* Cliqz */,
+				AC2CC4DC22DE026C00C5C85C /* CliqzDebug */,
 				1EE3850521416BB600B7F722 /* Ghostery */,
 				1E0B0B61217485810088C520 /* Paid */,
 				1E79A96F21A6F87300EAC6E6 /* Lumen */,
@@ -15400,6 +16278,7 @@
 				E6DCC2101DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FC9F1AEE7A6000869B6C /* Firefox */,
 				4F895F7322B12631002E6F0C /* Cliqz */,
+				AC2CC4E522DE026C00C5C85C /* CliqzDebug */,
 				1EE3850E21416BB600B7F722 /* Ghostery */,
 				1E0B0B6A217485810088C520 /* Paid */,
 				1E79A97821A6F87300EAC6E6 /* Lumen */,
@@ -15416,6 +16295,7 @@
 				E6DCC2081DCBB6F100CEC4B7 /* Fennec_Enterprise */,
 				E448FCA01AEE7A6000869B6C /* Firefox */,
 				4F895F6C22B12631002E6F0C /* Cliqz */,
+				AC2CC4DE22DE026C00C5C85C /* CliqzDebug */,
 				1EE3850721416BB600B7F722 /* Ghostery */,
 				1E0B0B63217485810088C520 /* Paid */,
 				1E79A97121A6F87300EAC6E6 /* Lumen */,

--- a/Client.xcodeproj/xcshareddata/xcschemes/CliqzDebug.xcscheme
+++ b/Client.xcodeproj/xcshareddata/xcschemes/CliqzDebug.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+               BuildableName = "Client.app"
+               BlueprintName = "Client"
+               ReferencedContainer = "container:Client.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Fennec"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "CliqzDebug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Fennec"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F84B21BD1A090F8100AAB793"
+            BuildableName = "Client.app"
+            BlueprintName = "Client"
+            ReferencedContainer = "container:Client.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Fennec">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Fennec"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Cliqz/Extensions/BrowserDBExtensions.swift
+++ b/Cliqz/Extensions/BrowserDBExtensions.swift
@@ -1,0 +1,17 @@
+//
+//  BrowserDBExtensions.swift
+//  Client
+//
+//  Created by Daniel Jilg on 17.07.19.
+//  Copyright © 2019 Cliqz. All rights reserved.
+//
+
+import Foundation
+import Deferred
+import Shared
+
+extension BrowserDB {
+    func extendedInit() {
+        
+    }
+}

--- a/Cliqz/Extensions/BrowserDBExtensions.swift
+++ b/Cliqz/Extensions/BrowserDBExtensions.swift
@@ -27,23 +27,35 @@ extension BrowserDB {
     /// `bookmarksLocal.bookmarked_date` which was introduced by Old Cliqz Mobile for this reason. We translate that
     /// sorting into `bookmarksLocalStructure.idx`, which seems intended for sorting by Firefox Mobile.
     private func migrateCliqzBookmarks() {
-        // TODO: Get all unmigrated bookmarks, sorted by bookmarked_date
-        let getUnmigratedBookmarksSQL = """
-            SELECT * FROM 'bookmarksLocal'
-            LEFT JOIN bookmarksLocalStructure ON bookmarksLocal.guid = bookmarksLocalStructure.child
+        // Get all unmigrated bookmarks, sorted by bookmarked_date
+        let fetchUnmigratedBookmarksSQL = """
+            SELECT * FROM \(TableBookmarksLocal)
+            LEFT JOIN \(TableBookmarksLocalStructure) ON \(TableBookmarksLocal).guid = \(TableBookmarksLocalStructure).child
             WHERE parentid = 'mobile______'
             AND child is NULL
             ORDER BY bookmarked_date
             """
+        let results = self.runQuery(fetchUnmigratedBookmarksSQL, args: nil, factory: BookmarkFactory.factory).value
+        guard let oldBookmarks = results.successValue else { return }
 
-        // TODO: Get highest idx value to add on top
-        let getHighestIDXValueForMobileSQL = """
-            SELECT idx FROM bookmarksLocalStructure
+        // Get highest idx value to add on top
+        let fetchHighestIDXValueForMobileSQL = """
+            SELECT idx FROM \(TableBookmarksLocalStructure)
             WHERE parent =  "mobile______"
             ORDER BY idx DESC
             LIMIT 1
             """
+        guard let highestIDXResults = self.runQuery(fetchHighestIDXValueForMobileSQL, args: nil, factory: BrowserDB.idxFactory).value.successValue else { return }
+        var highestIDX = 0
+        for value in highestIDXResults where value != nil { highestIDX = value! }
+
+        print(highestIDX)
+
 
         // TODO: Create entries to bookmarksLocalStructure with updated idx's
+    }
+
+    private class func idxFactory(_ row: SDRow) -> Int {
+        return row["idx"] as! Int
     }
 }

--- a/Cliqz/Extensions/BrowserDBExtensions.swift
+++ b/Cliqz/Extensions/BrowserDBExtensions.swift
@@ -9,23 +9,59 @@
 import Foundation
 import Deferred
 import Shared
+import Sentry
 
+// Cliqz
 extension BrowserDB {
-    func extendedInit() {
-        // TODO: Only run this once at migration time
+    static func preInit(filename: String, secretKey: String? = nil, schema: Schema, files: FileAccessor) {
+        moveOldDatabase(filename: filename, schema: schema, files: files)
+    }
+    
+    func postInit() {
         migrateCliqzBookmarks()
+    }
+
+    // MARK: - Private Implementation
+
+    /// If Old Cliqz Mobile left a database file in the wrong location, move it to the right location
+    ///
+    /// Old Cliqz Mobile puts the database file in `Documents/profile.profile/` whereas the current project expects the database to live in
+    /// `profile.profile/` (one level up).
+    ///
+    /// If a profile.profile folder exists in the `Documents` directory, we move it one level up. This ensures the migration code will find
+    /// the database and do its work.
+    private static func moveOldDatabase(filename: String, secretKey: String? = nil, schema: Schema, files: FileAccessor) {
+        // TODO
+        let newProfilePath = URL(fileURLWithPath: files.rootPath)
+        let appSandboxPath = newProfilePath.deletingLastPathComponent()
+        let oldProfilePath = appSandboxPath.appendingPathComponent("Documents").appendingPathComponent("profile.profile")
+
+        let fileManager = FileManager()
+        if fileManager.fileExists(atPath: oldProfilePath.path) {
+            do {
+                // Check if new folder exists but is empty and if yes delete it
+                if fileManager.fileExists(atPath: newProfilePath.path),
+                    try fileManager.contentsOfDirectory(atPath: newProfilePath.path).count == 0 {
+                    try fileManager.removeItem(at: newProfilePath)
+                }
+
+                // Move old folder to new location
+                try fileManager.moveItem(at: oldProfilePath, to: newProfilePath)
+            } catch let e {
+                Sentry.shared.send(message: "Failed to move old database to new location: \(e)", tag: .browserDB,
+                                   severity: .warning, extra: nil, description: e.localizedDescription, completion: nil)
+            }
+        }
     }
 
     /// Update the Database such that bookmarks from Old Cliqz Mobile show up in the new bookmarks menu.
     ///
-    /// In Old Cliqz Mobile, bookmarks would only get written to the `bookmarksLocal` table. However for them
-    /// to show up in this project, the bookmarks need a reference and sort order in the `bookmarksLocalStructure`
-    /// table as well.
+    /// In Old Cliqz Mobile, bookmarks would only get written to the `bookmarksLocal` table. However for them to show up in this project,
+    /// the bookmarks need a reference and sort order in the `bookmarksLocalStructure` table as well.
     ///
-    /// In this method we try to find any bookmarks without that reference and write an entry to
-    /// `bookmarksLocalStructure` for them, causing them to show up. For sorting, we use the colum
-    /// `bookmarksLocal.bookmarked_date` which was introduced by Old Cliqz Mobile for this reason. We translate that
-    /// sorting into `bookmarksLocalStructure.idx`, which seems intended for sorting by Firefox Mobile.
+    /// In this method we try to find any bookmarks without that reference and write an entry to `bookmarksLocalStructure` for them,
+    /// causing them to show up. For sorting, we use the colum `bookmarksLocal.bookmarked_date` which was introduced by Old Cliqz Mobile
+    /// for this reason. We translate that sorting into `bookmarksLocalStructure.idx`, which seems intended for sorting by Firefox Mobile.
     private func migrateCliqzBookmarks() {
         // Get all unmigrated bookmarks, sorted by bookmarked_date
         let fetchUnmigratedBookmarksSQL = """
@@ -36,7 +72,7 @@ extension BrowserDB {
             ORDER BY bookmarked_date
             """
         let results = self.runQuery(fetchUnmigratedBookmarksSQL, args: nil, factory: BookmarkFactory.factory).value
-        guard let oldBookmarks = results.successValue else { return }
+        guard let oldBookmarks = results.successValue, oldBookmarks.count > 0 else { return }
 
         // Get highest idx value to add on top
         let fetchHighestIDXValueForMobileSQL = """
@@ -45,14 +81,21 @@ extension BrowserDB {
             ORDER BY idx DESC
             LIMIT 1
             """
-        guard let highestIDXResults = self.runQuery(fetchHighestIDXValueForMobileSQL, args: nil, factory: BrowserDB.idxFactory).value.successValue else { return }
+        guard let highestIDXResults = self.runQuery(fetchHighestIDXValueForMobileSQL, args: nil,
+                                                    factory: BrowserDB.idxFactory).value.successValue else { return }
         var highestIDX = 0
         for value in highestIDXResults where value != nil { highestIDX = value! }
 
-        print(highestIDX)
-
-
-        // TODO: Create entries to bookmarksLocalStructure with updated idx's
+        // Create entries to bookmarksLocalStructure with updated idx's
+        let insertIntoBookmarksLocalStructureSQL = """
+            INSERT INTO \(TableBookmarksLocalStructure)
+            ('parent', 'child', 'idx')
+            VALUES (?, ?, ?);
+            """
+        for oldBookmark in oldBookmarks where oldBookmark != nil {
+            highestIDX += 1
+            _ = self.run(insertIntoBookmarksLocalStructureSQL, withArgs: ["mobile______", oldBookmark!.guid, highestIDX])
+        }
     }
 
     private class func idxFactory(_ row: SDRow) -> Int {

--- a/Cliqz/Extensions/BrowserDBExtensions.swift
+++ b/Cliqz/Extensions/BrowserDBExtensions.swift
@@ -12,6 +12,38 @@ import Shared
 
 extension BrowserDB {
     func extendedInit() {
-        
+        // TODO: Only run this once at migration time
+        migrateCliqzBookmarks()
+    }
+
+    /// Update the Database such that bookmarks from Old Cliqz Mobile show up in the new bookmarks menu.
+    ///
+    /// In Old Cliqz Mobile, bookmarks would only get written to the `bookmarksLocal` table. However for them
+    /// to show up in this project, the bookmarks need a reference and sort order in the `bookmarksLocalStructure`
+    /// table as well.
+    ///
+    /// In this method we try to find any bookmarks without that reference and write an entry to
+    /// `bookmarksLocalStructure` for them, causing them to show up. For sorting, we use the colum
+    /// `bookmarksLocal.bookmarked_date` which was introduced by Old Cliqz Mobile for this reason. We translate that
+    /// sorting into `bookmarksLocalStructure.idx`, which seems intended for sorting by Firefox Mobile.
+    private func migrateCliqzBookmarks() {
+        // TODO: Get all unmigrated bookmarks, sorted by bookmarked_date
+        let getUnmigratedBookmarksSQL = """
+            SELECT * FROM 'bookmarksLocal'
+            LEFT JOIN bookmarksLocalStructure ON bookmarksLocal.guid = bookmarksLocalStructure.child
+            WHERE parentid = 'mobile______'
+            AND child is NULL
+            ORDER BY bookmarked_date
+            """
+
+        // TODO: Get highest idx value to add on top
+        let getHighestIDXValueForMobileSQL = """
+            SELECT idx FROM bookmarksLocalStructure
+            WHERE parent =  "mobile______"
+            ORDER BY idx DESC
+            LIMIT 1
+            """
+
+        // TODO: Create entries to bookmarksLocalStructure with updated idx's
     }
 }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -164,20 +164,20 @@ SPEC CHECKSUMS:
   glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
   KKDomain: 6883615bda1dfc6a6257f399ee85a02618837757
   Purchases: 17496bdab0d0fb678f5f647c4c7039bca3b8263c
-  React: 1d605e098d69bdf08960787f3446f0a9dc2e2ccf
-  react-native-webrtc: b80865c92f8caec8b13d1e692192e56aecb42a7c
+  React: 5cb71fb1a15b5ce04794ab49e24b48ebe4c94e65
+  react-native-webrtc: 541532f2a980f99f4d83dcfb93aec042d5b51027
   Realm: 9eaecad54712d6246d08ba34c10f354e4715d7d3
   RealmSwift: 1fe08b4ebaeeaacf17f9ba0343f7b25c9fc31fa6
-  RNDeviceInfo: b375b3374cda3203d6d48cea8c07e46ba1169e26
-  RNFS: fefeffc4f25a76144c1b53dc0a3258cf64c99962
-  RNSqlite2: a9a2670679d6adcbcc7ea05698113803c2e62c33
-  RNUserAgent: bb2dfbd3428cdcbc83ec1a335d3026a8cbb02204
-  RNViewShot: fdf9a64f0621ebc4e7c3392a10d2ffb70a7faee4
+  RNDeviceInfo: dc3cbee96cd2392cf03d6ff6191dc15f1606a166
+  RNFS: 44ef20bb355e894d86a439be668c3c5ac70838a5
+  RNSqlite2: 181ae6674f53598008e7a64d8c2273c3df5d98b7
+  RNUserAgent: 09aeb4cb0a23f9a8d406d3c88ee37ab0a9c65d78
+  RNViewShot: 1ac55a15ad999abc4175ec9b9767d6b02697b1ac
   RxAtomic: eacf60db868c96bfd63320e28619fe29c179656f
   RxSwift: 5976ecd04fc2fefd648827c23de5e11157faa973
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  yoga: 128daf064cacaede0c3bb27424b6b4c71052e6cd
+  yoga: 596e61c9b57751d08a22b07aba310dbd3e65ab75
 
 PODFILE CHECKSUM: 6c421bc1c58bb527722fc9ee7e749de3a6c712f7
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.7.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -164,20 +164,20 @@ SPEC CHECKSUMS:
   glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
   KKDomain: 6883615bda1dfc6a6257f399ee85a02618837757
   Purchases: 17496bdab0d0fb678f5f647c4c7039bca3b8263c
-  React: 5cb71fb1a15b5ce04794ab49e24b48ebe4c94e65
-  react-native-webrtc: 541532f2a980f99f4d83dcfb93aec042d5b51027
+  React: 1d605e098d69bdf08960787f3446f0a9dc2e2ccf
+  react-native-webrtc: b80865c92f8caec8b13d1e692192e56aecb42a7c
   Realm: 9eaecad54712d6246d08ba34c10f354e4715d7d3
   RealmSwift: 1fe08b4ebaeeaacf17f9ba0343f7b25c9fc31fa6
-  RNDeviceInfo: dc3cbee96cd2392cf03d6ff6191dc15f1606a166
-  RNFS: 44ef20bb355e894d86a439be668c3c5ac70838a5
-  RNSqlite2: 181ae6674f53598008e7a64d8c2273c3df5d98b7
-  RNUserAgent: 09aeb4cb0a23f9a8d406d3c88ee37ab0a9c65d78
-  RNViewShot: 1ac55a15ad999abc4175ec9b9767d6b02697b1ac
+  RNDeviceInfo: b375b3374cda3203d6d48cea8c07e46ba1169e26
+  RNFS: fefeffc4f25a76144c1b53dc0a3258cf64c99962
+  RNSqlite2: a9a2670679d6adcbcc7ea05698113803c2e62c33
+  RNUserAgent: bb2dfbd3428cdcbc83ec1a335d3026a8cbb02204
+  RNViewShot: fdf9a64f0621ebc4e7c3392a10d2ffb70a7faee4
   RxAtomic: eacf60db868c96bfd63320e28619fe29c179656f
   RxSwift: 5976ecd04fc2fefd648827c23de5e11157faa973
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
-  yoga: 596e61c9b57751d08a22b07aba310dbd3e65ab75
+  yoga: 128daf064cacaede0c3bb27424b6b4c71052e6cd
 
 PODFILE CHECKSUM: 6c421bc1c58bb527722fc9ee7e749de3a6c712f7
 
-COCOAPODS: 1.7.2
+COCOAPODS: 1.5.3

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -28,6 +28,11 @@ open class BrowserDB {
         }
 
         self.db = SwiftData(filename: file, key: secretKey, prevKey: nil, schema: schema, files: files)
+
+        if filename == "browser.db" {
+            // Cliqz: new method call to extend tables if needed
+            self.extendedInit()
+        }
     }
 
     // For testing purposes or other cases where we want to ensure that this `BrowserDB`

--- a/Storage/SQL/BrowserDB.swift
+++ b/Storage/SQL/BrowserDB.swift
@@ -19,6 +19,11 @@ open class BrowserDB {
     open static let MaxVariableNumber = 999
 
     public init(filename: String, secretKey: String? = nil, schema: Schema, files: FileAccessor) {
+        // Cliqz
+        if filename == "browser.db" {
+            BrowserDB.preInit(filename: filename, schema: schema, files: files)
+        }
+
         log.debug("Initializing BrowserDB: \(filename).")
 
         let file = URL(fileURLWithPath: (try! files.getAndEnsureDirectory())).appendingPathComponent(filename).path
@@ -29,9 +34,9 @@ open class BrowserDB {
 
         self.db = SwiftData(filename: file, key: secretKey, prevKey: nil, schema: schema, files: files)
 
+        // Cliqz
         if filename == "browser.db" {
-            // Cliqz: new method call to extend tables if needed
-            self.extendedInit()
+            self.postInit()
         }
     }
 


### PR DESCRIPTION
This extends the `BrowserDB` class so that before accessing the database for the first time the following will happen:

1. Check if a `profile.profile` folder exists in the place where Old Cliqz Mobile put it, and if yes, move it to the new location for the current code to find
2. When accessing bookmarks for the first time, check if there are any bookmarks without a `bookmarksLocalStructure` entry. If yes, create that entry for those bookmarks. This fixes a bug where they would not show up in the bookmarks tab.

## Bonus Content
I added a Cliqz Debug scheme and unreleased behind the scenes commentary.

## Pull Request Checklist

- [x] My PR has a standard commit message that looks like `[IP-123] This fixes something something`
- [x] I have updated the *Unit Tests* to cover new or changed functionality
- [x] I have made sure that localizable strings use `NSLocalizableString()`

## Notes for testing this patch

To test, install Old Cliqz Mobile from the App Store and install this code on top of it via Xcode. 


[IP-123]: https://cliqztix.atlassian.net/browse/IP-123