### PR TITLE
Remove “Ghostery Rewards” from Cliqz Settings

### DIFF
--- a/Cliqz/Settings/CliqzAppSettingsTableViewController.swift
+++ b/Cliqz/Settings/CliqzAppSettingsTableViewController.swift
@@ -218,7 +218,6 @@ class CliqzAppSettingsTableViewController: AppSettingsTableViewController {
 				FAQSetting(delegate: settingsDelegate),
 				SendCrashReportsSetting(settings: self),
 				SendUsageDataSetting(settings: self),
-				MyOffrzSetting()
 			]
         #endif
         


### PR DESCRIPTION
Fixes #425
