### PR TITLE
Cliqz: rename quick action New Private Tab - fixes #459

### DIFF
--- a/Client/Configuration/Cliqz.xcconfig
+++ b/Client/Configuration/Cliqz.xcconfig
@@ -19,7 +19,7 @@ MOZ_INTERNAL_URL_SCHEME = cliqz
 
 LAUNCH_SCREEN = CliqzLaunchScreen
 
-SHORTCUT_PRIVATE_TAB_TITLE = ShortcutItemTitleNewForgetTab
+SHORTCUT_PRIVATE_TAB_TITLE = ShortcutItemTitleNewPrivateTab
 
 SHORTCUT_PRIVATE_TAB_ICON = quick_action_new_private_tab
 


### PR DESCRIPTION
Translations for "New Forget Tab" fail and there are more inconsistencies with
Forget/Private tabs so it is not worth to fight with that one string now.
