### PR TITLE
Delist simply.com

### DIFF
--- a/Client/Frontend/ContentBlocker/Lists/disconnect-advertising.json
+++ b/Client/Frontend/ContentBlocker/Lists/disconnect-advertising.json
@@ -437,8 +437,6 @@
 {"action":{"type":"block"},"trigger":{"url-filter":"^https?://([^/]+\\.)?traffiliate\\.com","load-type":["third-party"],"unless-domain":["*dsnrmg.com","*dsnrgroup.com","*traffiliate.com","*z5x.net"]}},
 {"action":{"type":"block"},"trigger":{"url-filter":"^https?://([^/]+\\.)?z5x\\.com","load-type":["third-party"],"unless-domain":["*dsnrmg.com","*dsnrgroup.com","*traffiliate.com","*z5x.net"]}},
 {"action":{"type":"block"},"trigger":{"url-filter":"^https?://([^/]+\\.)?z5x\\.net","load-type":["third-party"],"unless-domain":["*dsnrmg.com","*dsnrgroup.com","*traffiliate.com","*z5x.net"]}},
-{"action":{"type":"block"},"trigger":{"url-filter":"^https?://([^/]+\\.)?dada\\.pro","load-type":["third-party"],"unless-domain":["*dada.eu","*dada.pro","*simply.com"]}},
-{"action":{"type":"block"},"trigger":{"url-filter":"^https?://([^/]+\\.)?simply\\.com","load-type":["third-party"],"unless-domain":["*dada.eu","*dada.pro","*simply.com"]}},
 {"action":{"type":"block"},"trigger":{"url-filter":"^https?://([^/]+\\.)?dataxu\\.com","load-type":["third-party"],"unless-domain":["*dataxu.com","*mexad.com","*w55c.net"]}},
 {"action":{"type":"block"},"trigger":{"url-filter":"^https?://([^/]+\\.)?dataxu\\.net","load-type":["third-party"],"unless-domain":["*dataxu.com","*mexad.com","*w55c.net"]}},
 {"action":{"type":"block"},"trigger":{"url-filter":"^https?://([^/]+\\.)?mexad\\.com","load-type":["third-party"],"unless-domain":["*dataxu.com","*mexad.com","*w55c.net"]}},


### PR DESCRIPTION
We aquired simply.com and are working on launching a webhosting project on it. However the domain is blocked by you, due to past advertising activity (before we bought it).

Can you delist the domain from your blocklists?